### PR TITLE
Reset frameCounter when playing new animation

### DIFF
--- a/direction.go
+++ b/direction.go
@@ -36,7 +36,7 @@ func DirectionFromString(str string) Direction {
 	case PlayReverse.String():
 		return PlayReverse
 	case PlayPingPong.String():
-		return PlayReverse
+		return PlayPingPong
 	case PlayForward.String():
 		fallthrough
 	default:

--- a/info.go
+++ b/info.go
@@ -44,6 +44,7 @@ func (i *AnimationInfo) playAnimation(anim *Animation) {
 	if i.CurrentAnimation.Direction == PlayReverse {
 		i.CurrentFrame = i.CurrentAnimation.To
 	}
+	i.frameCounter = 0
 }
 
 func (i *AnimationInfo) advanceFrame() {

--- a/meta.go
+++ b/meta.go
@@ -45,7 +45,7 @@ type Animation struct {
 	//  - PlayForward
 	//  - PlayReverse
 	//  - PlayPingPong
-	Direction Direction `json:"direction"`
+	Direction Direction `json:"direction,string"`
 }
 
 // Layer contains the data about the individual animation layer


### PR DESCRIPTION
I noticed the frameCounter does not resets when a new animation is played. This causes that the frameCounter carries over to the first frame of the next animation. I'm aware this only happens when interrupting the current animation with a new one. This may be unintended use of the library, if that's the case, I'll like to discuss the implications for allowing this behavior.

Also, I fixed the direction parsing on a second commit, without the `` `json:"direction, string"` `` the string comparison for detection would be `"pingpong" != pingpong`.

Great library BTW thank you for your work.